### PR TITLE
fixed StdArray

### DIFF
--- a/facebook/yoga/StdArray.hx
+++ b/facebook/yoga/StdArray.hx
@@ -1,28 +1,27 @@
 package facebook.yoga;
 
+import cpp.RawPointer;
+
 @:unreflective
 @:structAccess
 @:native("std::array")
 extern class StdArrayImpl<T> {
-    public var data(get, never):cpp.RawPointer<T>;
+	@:noCompletion
+	public var data(get, never):RawPointer<T>;
 	public var length(get, never):Int;
-	
+
 	@:native('size')
 	public function get_length():Int;
 
-	@:native('at')
-	public function at(index:Int):T;
+	@:native('data')
+	public function get_data():RawPointer<T>;
 }
 
 @:forward
 abstract StdArray<T>(StdArrayImpl<T>) {
 	@:arrayAccess
-	public inline function get(index:Int):T {
-		return this.at(index);
-	}
+	public inline function get(index:Int):T return this.data[index];
 
 	@:arrayAccess
-	public inline function set(index:Int, value:T):T {				
-		return this.data[index] = value;
-	}    
+	public inline function set(index:Int, value:T):T return this.data[index] = value;
 }


### PR DESCRIPTION
* essential method get_data was missing (I got compilation errors: C3203, C2440, C2227)
* that range guard with "at" is pointless because we can't catch "out of range" exception on haxe's side, so I got rid of it and made a getter and a setter consistent

Actually, we don't need a value setter and a length property therefore could replace StdArray<T> with RawPointer<T> and still have [] access to items 